### PR TITLE
Initial commit of OpenSeaDragon annotation section for pict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+.DS_Store
+.babelrc
+.browserslistrc
+.browserslistrc-BACKUP
+.gulpfile-quackage-config.json
+.gulpfile-quackage.js
+.package.json.quackage.bak
+
+package-lock.json
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # pict-section-openseadragon
+Open Sea Dragon Configurable Pict Section

--- a/example_applications/photo_example/.quackage.json
+++ b/example_applications/photo_example/.quackage.json
@@ -1,0 +1,9 @@
+{
+	"GulpExecutions": [
+	{
+		"Hash": "default",
+		"Name": "Default standard build.",
+		"BuildFileLabel": "",
+		"BrowsersListRC": "since 2022"
+	}]
+}

--- a/example_applications/photo_example/README-SimpleForm.md
+++ b/example_applications/photo_example/README-SimpleForm.md
@@ -1,0 +1,6 @@
+# Minimum Viable Forms Application
+
+To run this, install dependencies in the root of the repository with a `npm install`
+and then navigate to this folder and run `npm run build` to build the dist files
+(which are not checked in).  Then, you should be able to open index.html in the dist
+foder from your favorite browser.

--- a/example_applications/photo_example/Simple-Image-Viewer-Application.js
+++ b/example_applications/photo_example/Simple-Image-Viewer-Application.js
@@ -1,0 +1,226 @@
+const libPictApplication = require('pict-application');
+
+const libPictSectionOpenSeaDragon = require('../../source/Pict-Section-OpenSeaDragon.js');
+
+class ExampleImageView extends libPictSectionOpenSeaDragon
+{
+	constructor(pFable, pOptions, pServiceHash)
+	{
+		super(pFable, pOptions, pServiceHash);
+	}
+}
+
+// Need to construct the url for where the icons for openseadragon are hosted (in this case just relative in the dist folder).
+const pathname = window.location.pathname;
+const tokens = pathname.split('/');
+tokens.pop();
+const newUrl = tokens.join('/') + '/images/';
+
+const ExampleImageConfiguration = (
+{
+	"ViewIdentifier": "ExamplePhotoViewer",
+	"EnableAnnotation": true,
+	"PrefixUrl": newUrl,
+	"ViewAddress": "ExampleImageView",
+	"TileSources":
+	{
+		Image: {
+			xmlns: "http://schemas.microsoft.com/deepzoom/2008",
+			Url: "https://openseadragon.github.io/example-images/duomo/duomo_files/",
+			Format: "jpg",
+			Overlap: "2",
+			TileSize: "256",
+			Size: {
+				Width:  "13920",
+				Height: "10200"
+			}
+		}
+	},
+	"Colors": 
+	{
+		"red": "red",
+		"green": "green",
+		"blue": "blue",
+		"cyan": "#4dd0e1",
+		"deep-purple": "#673ab7",
+		"pink": "#ff4081"
+	},
+	"Annotations": 
+	[
+		{
+			"@context": "http://www.w3.org/ns/anno.jsonld",
+			"type": "Annotation",
+			"body": [],
+			"stylesheet": {
+				"type": "CssStylesheet",
+				"value": ".pink { stroke: #ff4081 !important; stroke-width: 2 !important; }"
+			},
+			"target": {
+				"source": "",
+				"selector": {
+					"type": "FragmentSelector",
+					"conformsTo": "http://www.w3.org/TR/media-frags/",
+					"value": "xywh=pixel:2645.419677734375,3208.516845703125,4804.665771484375,3968.359619140625"
+				},
+				"styleClass": "pink"
+			},
+			"id": "#aba6a91a-9780-4e7b-9a3d-5380423162c7"
+		},
+		{
+			"@context": "http://www.w3.org/ns/anno.jsonld",
+			"type": "Annotation",
+			"body": [],
+			"stylesheet": {
+				"type": "CssStylesheet",
+				"value": ".cyan { stroke: #4dd0e1 !important; stroke-width: 2 !important; }"
+			},
+			"target": {
+				"source": "",
+				"selector": {
+					"type": "SvgSelector",
+					"value": "<svg><line x1=\"3294.521484375\" y1=\"9533.80859375\" x2=\"10204.3251953125\" y2=\"3381.527099609375\"></line></svg>"
+				},
+				"renderedVia": {
+					"name": "line"
+				},
+				"styleClass": "cyan"
+			},
+			"id": "#c8d1d4b9-7a15-40f2-a2c4-7e2977070fe8"
+		},
+		{
+			"type": "Annotation",
+			"body": [],
+			"stylesheet": {
+				"type": "CssStylesheet",
+				"value": ".blue { stroke: blue !important; stroke-width: 2 !important; }"
+			},
+			"target": {
+				"source": "",
+				"selector": {
+					"type": "SvgSelector",
+					"value": "<svg><polygon points=\"5156.021484375,1708.80615234375 5121.77490234375,4228.82421875 9119.7294921875,3172.92822265625 7975.3447265625,2410.005126953125\" /></svg>"
+				},
+				"styleClass": "blue"
+			},
+			"@context": "http://www.w3.org/ns/anno.jsonld",
+			"id": "#2612129b-96a9-4b8c-8bef-69e12886bc56"
+		},
+		{
+			"@context": "http://www.w3.org/ns/anno.jsonld",
+			"type": "Annotation",
+			"body": [
+				{
+					"type": "TextualBody",
+					"value": "Test Comment squiggle",
+					"purpose": "commenting"
+				},
+				{
+					"type": "TextualBody",
+					"value": "Test Tag",
+					"purpose": "tagging"
+				},
+				{
+					"type": "TextualBody",
+					"value": "Test Comment Reply",
+					"purpose": "commenting"
+				}
+			],
+			"stylesheet": {
+				"type": "CssStylesheet",
+				"value": ".cyan { stroke: #4dd0e1 !important; stroke-width: 2 !important; }"
+			},
+			"target": {
+				"source": "",
+				"selector": {
+					"type": "SvgSelector",
+					"value": "<svg><path d=\"M2859.190185546875 5282.3310546875 L2558.54052734375 5237.14697265625 L1744.520751953125 5147.52001953125 L1309.6341552734375 5111.05224609375 L988.37890625 5112.365234375 L787.1219482421875 5163.7802734375 L578.3851318359375 5279.74560546875 L382.9145202636719 5452.884765625 L231.9209442138672 5673.6572265625 L130.70794677734375 5917.58984375 L96.66393280029297 6110.72119140625 L113.61854553222656 6281.34228515625 L151.94410705566406 6410.97705078125 L232.88900756835938 6508.69873046875 L385.1839599609375 6592.88671875 L690.7075805664062 6653.01904296875 L1248.4622802734375 6686.08740234375 L2167.1875 6648.5888671875 L3201.23486328125 6577.080078125 L4193.65087890625 6482.27978515625 L5097.97021484375 6354.005859375 L5786.984375 6194.80322265625 L6377.5556640625 6030.09619140625 L6809.05517578125 5932.353515625 L7137.6357421875 5900.43798828125 L7398.33447265625 5901.15234375 L7550.31298828125 5928.66650390625 L7643.73974609375 5966.16943359375 L7697.9169921875 6022.60205078125 L7736.08349609375 6104.65185546875 L7755.60888671875 6218.7744140625 L7766.671875 6363.4267578125 L7758.33935546875 6543.5166015625 L7719.47216796875 6775.92626953125 L7655.95703125 7031.11181640625 L7561.79736328125 7313.01611328125 L7431.794921875 7625.50830078125 L7284.8427734375 7871.85009765625 L7077.44921875 8101.3720703125 L6847.65966796875 8295.0361328125 L6591.490234375 8431.6240234375 L6289.7802734375 8530.6484375 L5934.90966796875 8569.0771484375 L5498.54296875 8587.419921875 L4911.52587890625 8557.8828125 L4287.40576171875 8490.6845703125 L3731.925537109375 8392.0048828125 L3227.34326171875 8305.0166015625 L2858.608642578125 8252.8408203125 L2603.367919921875 8217.2607421875 L2485.54345703125 8204.525390625 L2454.01904296875 8203.71484375 L2439.26025390625 8203.033203125 L2433.2412109375 8202.25390625 L2433.2412109375 8202.25390625\"></path></svg>"
+				},
+				"styleClass": "cyan"
+			},
+			"id": "#7bfead2d-313c-4efc-a44c-58f377acfa9e"
+		},
+		{
+			"@context": "http://www.w3.org/ns/anno.jsonld",
+			"type": "Annotation",
+			"body": [
+				{
+					"type": "TextualBody",
+					"value": "Test comment",
+					"purpose": "commenting"
+				},
+				{
+					"type": "TextualBody",
+					"value": "Test Tag",
+					"purpose": "tagging"
+				}
+			],
+			"stylesheet": {
+				"type": "CssStylesheet",
+				"value": ".red { stroke: red !important; stroke-width: 2 !important; }"
+			},
+			"target": {
+				"source": "",
+				"selector": {
+					"type": "SvgSelector",
+					"value": "<svg><line x1=\"4419.302734375\" y1=\"4627.744140625\" x2=\"13797.0009765625\" y2=\"9454.41796875\"></line></svg>"
+				},
+				"renderedVia": {
+					"name": "line"
+				},
+				"styleClass": "red"
+			},
+			"id": "#6ee8b86f-0667-4ce7-9615-63cd84b2cacf"
+		},
+		{
+			"@context": "http://www.w3.org/ns/anno.jsonld",
+			"type": "Annotation",
+			"body": [
+				{
+					"type": "TextualBody",
+					"value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+					"purpose": "commenting"
+				}
+			],
+			"stylesheet": {
+				"type": "CssStylesheet",
+				"value": ".deep-purple { stroke: #673ab7 !important; stroke-width: 2 !important; }"
+			},
+			"target": {
+				"source": "",
+				"selector": {
+					"type": "SvgSelector",
+					"value": "<svg><ellipse cx=\"7838.73193359375\" cy=\"6904.47216796875\" rx=\"2798.57958984375\" ry=\"1622.33154296875\"></ellipse></svg>"
+				},
+				"styleClass": "deep-purple"
+			},
+			"id": "#1632ac19-51f2-4fa5-b3b7-5e6382c4ff2e"
+		}
+	]
+});
+
+class PostcardApplication extends libPictApplication
+{
+	constructor(pFable, pOptions, pServiceHash)
+	{
+		super(pFable, pOptions, pServiceHash);
+
+		this.pict.addView('ExampleImageView', Object.assign(libPictSectionOpenSeaDragon.default_configuration, ExampleImageConfiguration), ExampleImageView);
+	}
+};
+
+module.exports = PostcardApplication
+
+module.exports.default_configuration = ({
+	"Name": "A Simple Image Annotation application",
+	"Hash": "Image",
+
+	"MainViewportViewIdentifier": "ExampleImageView",
+
+	"pict_configuration":
+		{
+			"Product": "Image-Application",
+
+			"DefaultAppData": {
+			}
+		}
+});

--- a/example_applications/photo_example/html/index.html
+++ b/example_applications/photo_example/html/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>Simple.</title>
+		<style id="PICT-CSS"></style>
+		<link href="annotorious.min.css" rel="stylesheet">
+		<script src="./pict.min.js" type="text/javascript"></script>
+		<script type="text/javascript">Pict.safeOnDocumentReady(() => { Pict.safeLoadPictApplication(SimpleImageviewer, 1)});</script>
+	</head>
+	<body>
+		<div id="OpenSeaDragon-Container-Div" style="width:800px; height:600px;"></div>
+		<script src="./openseadragon.3.0.0.min.js" type="text/javascript"></script>
+		<script src="./openseadragon-annotorious.min.js" type="text/javascript"></script>
+		<script src="./annotorious-toolbar.min.js" type="text/javascript"></script>
+		<script src="./annotorious-selector-pack.js" type="text/javascript"></script>
+		<script src="./annotorious-better-polygon.js" type="text/javascript"></script>
+		<script src="./simple_imageviewer.min.js" type="text/javascript"></script>
+	</body>
+</html>

--- a/example_applications/photo_example/package.json
+++ b/example_applications/photo_example/package.json
@@ -1,0 +1,62 @@
+{
+    "name": "simple_imageviewer",
+    "version": "1.0.0",
+    "description": "Basic Image Viewer Application",
+    "main": "Simple-Image-Viewer-Application.js",
+    "scripts": {
+        "start": "node Simple-Image-Viewer-Application.js",
+        "build": "npx quack build && npx quack copy"
+    },
+    "author": "steven",
+    "license": "MIT",
+    "copyFilesSettings": {
+        "whenFileExists": "overwrite"
+    },
+    "copyFiles": [
+        {
+            "from": "./html/*",
+            "to": "./dist/"
+        },
+        {
+            "from": "./node_modules/@recogito/annotorious-openseadragon/dist/annotorious.min.css",
+            "to": "./dist/"
+        },
+        {
+            "from": "./node_modules/@recogito/annotorious-openseadragon/dist/openseadragon-annotorious.min.js",
+            "to": "./dist/"
+        },
+        {
+            "from": "./node_modules/@recogito/annotorious-openseadragon/dist/recogito-polyfills.js",
+            "to": "./dist/"
+        },
+        {
+            "from": "./node_modules/@recogito/annotorious-openseadragon/dist/openseadragon/**/*",
+            "to": "./dist/"
+        },
+        {
+            "from": "./node_modules/@recogito/annotorious-toolbar/dist/annotorious-toolbar.min.js",
+            "to": "./dist/"
+        },
+        {
+            "from": "./node_modules/@recogito/annotorious-selector-pack/dist/annotorious-selector-pack.js",
+            "to": "./dist/"
+        },
+        {
+            "from": "./node_modules/@recogito/annotorious-better-polygon/dist/annotorious-better-polygon.js",
+            "to": "./dist/"
+        },
+        {
+            "from": "../../node_modules/pict/dist/*",
+            "to": "./dist/"
+        }
+    ],
+    "dependencies": {
+        "pict": "^1.0.210",
+        "pict-application": "^1.0.19",
+        "pict-view": "^1.0.51",
+        "@recogito/annotorious-openseadragon": "^2.7.18",
+        "@recogito/annotorious-toolbar": "^1.2.1",
+        "@recogito/annotorious-better-polygon": "0.2.0",
+        "@recogito/annotorious-selector-pack": "0.6.1"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,53 @@
+{
+    "name": "pict-section-openseadragon",
+    "version": "1.0.26",
+    "description": "Pict Open Sea Dragon Section",
+    "main": "source/Pict-Section-OpenSeaDragon.js",
+    "scripts": {
+        "test": "mocha -u tdd -R spec",
+        "tests": "mocha -u tdd -R spec -g",
+        "start": "node source/Pict-Section-OpenSeaDragon.js",
+        "coverage": "./node_modules/.bin/nyc --reporter=lcov --reporter=text-lcov ./node_modules/mocha/bin/_mocha -- -u tdd -R spec",
+        "build": "quack build",
+        "docker-dev-build": "docker build ./ -f Dockerfile_LUXURYCode -t pict-section-openseadragon-image:local",
+        "docker-dev-run": "docker run -it -d --name pict-section-openseadragon-dev -p 30001:8080 -p 38086:8086 -v \"$PWD/.config:/home/coder/.config\"  -v \"$PWD:/home/coder/pict-section-openseadragon\" -u \"$(id -u):$(id -g)\" -e \"DOCKER_USER=$USER\" pict-section-openseadragon-image:local",
+        "docker-dev-shell": "docker exec -it pict-section-openseadragon-dev /bin/bash"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stevenvelozo/pict-section-openseadragon.git"
+    },
+    "author": "steven velozo <steven@velozo.com>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/stevenvelozo/pict-section-openseadragon/issues"
+    },
+    "homepage": "https://github.com/stevenvelozo/pict-section-openseadragon#readme",
+    "devDependencies": {
+        "bower": "^1.8.14",
+        "browser-env": "^3.3.0",
+        "pict": "^1.0.210",
+        "quackage": "^1.0.31"
+    },
+    "mocha": {
+        "diff": true,
+        "extension": [
+            "js"
+        ],
+        "package": "./package.json",
+        "reporter": "spec",
+        "slow": "75",
+        "timeout": "5000",
+        "ui": "tdd",
+        "watch-files": [
+            "source/**/*.js",
+            "test/**/*.js"
+        ],
+        "watch-ignore": [
+            "lib/vendor"
+        ]
+    },
+    "dependencies": {
+        "pict-view": "^1.0.51"
+    }
+}

--- a/source/OpenSeaDragon-Configuration.md
+++ b/source/OpenSeaDragon-Configuration.md
@@ -1,0 +1,678 @@
+# OpenSeaDragon configuration....
+
+```js
+ /**
+  * All required and optional settings for instantiating a new instance of an OpenSeadragon image viewer.
+  *
+  * @typedef {Object} Options
+  * @memberof OpenSeadragon
+  *
+  * @property {String} id
+  *     Id of the element to append the viewer's container element to. If not provided, the 'element' property must be provided.
+  *     If both the element and id properties are specified, the viewer is appended to the element provided in the element property.
+  *
+  * @property {Element} element
+  *     The element to append the viewer's container element to. If not provided, the 'id' property must be provided.
+  *     If both the element and id properties are specified, the viewer is appended to the element provided in the element property.
+  *
+  * @property {Array|String|Function|Object} [tileSources=null]
+  *     Tile source(s) to open initially. This is a complex parameter; see
+  *     {@link OpenSeadragon.Viewer#open} for details.
+  *
+  * @property {Number} [tabIndex=0]
+  *     Tabbing order index to assign to the viewer element. Positive values are selected in increasing order. When tabIndex is 0
+  *     source order is used. A negative value omits the viewer from the tabbing order.
+  *
+  * @property {Array} overlays Array of objects defining permanent overlays of
+  *     the viewer. The overlays added via this option and later removed with
+  *     {@link OpenSeadragon.Viewer#removeOverlay} will be added back when a new
+  *     image is opened.
+  *     To add overlays which can be definitively removed, one must use
+  *     {@link OpenSeadragon.Viewer#addOverlay}
+  *     If displaying a sequence of images, the overlays can be associated
+  *     with a specific page by passing the overlays array to the page's
+  *     tile source configuration.
+  *     Expected properties:
+  *     * x, y, (or px, py for pixel coordinates) to define the location.
+  *     * width, height in point if using x,y or in pixels if using px,py. If width
+  *       and height are specified, the overlay size is adjusted when zooming,
+  *       otherwise the size stays the size of the content (or the size defined by CSS).
+  *     * className to associate a class to the overlay
+  *     * id to set the overlay element. If an element with this id already exists,
+  *       it is reused, otherwise it is created. If not specified, a new element is
+  *       created.
+  *     * placement a string to define the relative position to the viewport.
+  *       Only used if no width and height are specified. Default: 'TOP_LEFT'.
+  *       See {@link OpenSeadragon.Placement} for possible values.
+  *
+  * @property {String} [xmlPath=null]
+  *     <strong>DEPRECATED</strong>. A relative path to load a DZI file from the server.
+  *     Prefer the newer Options.tileSources.
+  *
+  * @property {String} [prefixUrl='/images/']
+  *     Prepends the prefixUrl to navImages paths, which is very useful
+  *     since the default paths are rarely useful for production
+  *     environments.
+  *
+  * @property {OpenSeadragon.NavImages} [navImages]
+  *     An object with a property for each button or other built-in navigation
+  *     control, eg the current 'zoomIn', 'zoomOut', 'home', and 'fullpage'.
+  *     Each of those in turn provides an image path for each state of the button
+  *     or navigation control, eg 'REST', 'GROUP', 'HOVER', 'PRESS'. Finally the
+  *     image paths, by default assume there is a folder on the servers root path
+  *     called '/images', eg '/images/zoomin_rest.png'.  If you need to adjust
+  *     these paths, prefer setting the option.prefixUrl rather than overriding
+  *     every image path directly through this setting.
+  *
+  * @property {Boolean} [debugMode=false]
+  *     TODO: provide an in-screen panel providing event detail feedback.
+  *
+  * @property {String} [debugGridColor=['#437AB2', '#1B9E77', '#D95F02', '#7570B3', '#E7298A', '#66A61E', '#E6AB02', '#A6761D', '#666666']]
+  *     The colors of grids in debug mode. Each tiled image's grid uses a consecutive color.
+  *     If there are more tiled images than provided colors, the color vector is recycled.
+  *
+  * @property {Boolean} [silenceMultiImageWarnings=false]
+  *     Silences warnings when calling viewport coordinate functions with multi-image.
+  *     Useful when you're overlaying multiple images on top of one another.
+  *
+  * @property {Number} [blendTime=0]
+  *     Specifies the duration of animation as higher or lower level tiles are
+  *     replacing the existing tile.
+  *
+  * @property {Boolean} [alwaysBlend=false]
+  *     Forces the tile to always blend.  By default the tiles skip blending
+  *     when the blendTime is surpassed and the current animation frame would
+  *     not complete the blend.
+  *
+  * @property {Boolean} [autoHideControls=true]
+  *     If the user stops interacting with the viewport, fade the navigation
+  *     controls.  Useful for presentation since the controls are by default
+  *     floated on top of the image the user is viewing.
+  *
+  * @property {Boolean} [immediateRender=false]
+  *     Render the best closest level first, ignoring the lowering levels which
+  *     provide the effect of very blurry to sharp. It is recommended to change
+  *     setting to true for mobile devices.
+  *
+  * @property {Number} [defaultZoomLevel=0]
+  *     Zoom level to use when image is first opened or the home button is clicked.
+  *     If 0, adjusts to fit viewer.
+  *
+  * @property {String|DrawerImplementation|Array} [drawer = ['webgl', 'canvas', 'html']]
+  *     Which drawer to use. Valid strings are 'webgl', 'canvas', and 'html'. Valid drawer
+  *     implementations are constructors of classes that extend OpenSeadragon.DrawerBase.
+  *     An array of strings and/or constructors can be used to indicate the priority
+  *     of different implementations, which will be tried in order based on browser support.
+  *
+  * @property {Object} drawerOptions
+  *     Options to pass to the selected drawer implementation. For details
+  *     please see {@link OpenSeadragon.DrawerOptions}.
+  *
+  * @property {Number} [opacity=1]
+  *     Default proportional opacity of the tiled images (1=opaque, 0=hidden)
+  *     Hidden images do not draw and only load when preloading is allowed.
+  *
+  * @property {Boolean} [preload=false]
+  *     Default switch for loading hidden images (true loads, false blocks)
+  *
+  * @property {String} [compositeOperation=null]
+  *     Valid values are 'source-over', 'source-atop', 'source-in', 'source-out',
+  *     'destination-over', 'destination-atop', 'destination-in', 'destination-out',
+  *     'lighter', 'difference', 'copy', 'xor', etc.
+  *     For complete list of modes, please @see {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation/ globalCompositeOperation}
+  *
+  * @property {Boolean} [imageSmoothingEnabled=true]
+  *     Image smoothing for canvas rendering (only if the canvas drawer is used). Note: Ignored
+  *     by some (especially older) browsers which do not support this canvas property.
+  *     This property can be changed in {@link Viewer.DrawerBase.setImageSmoothingEnabled}.
+  *
+  * @property {String|CanvasGradient|CanvasPattern|Function} [placeholderFillStyle=null]
+  *     Draws a colored rectangle behind the tile if it is not loaded yet.
+  *     You can pass a CSS color value like "#FF8800".
+  *     When passing a function the tiledImage and canvas context are available as argument which is useful when you draw a gradient or pattern.
+  *
+  * @property {Object} [subPixelRoundingForTransparency=null]
+  *     Determines when subpixel rounding should be applied for tiles when rendering images that support transparency.
+  *     This property is a subpixel rounding enum values dictionary [{@link BROWSERS}] --> {@link SUBPIXEL_ROUNDING_OCCURRENCES}.
+  *     The key is a {@link BROWSERS} value, and the value is one of {@link SUBPIXEL_ROUNDING_OCCURRENCES},
+  *     indicating, for a given browser, when to apply subpixel rounding.
+  *     Key '*' is the fallback value for any browser not specified in the dictionary.
+  *     This property has a simple mode, and one can set it directly to
+  *     {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER}, {@link SUBPIXEL_ROUNDING_OCCURRENCES.ONLY_AT_REST} or {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS}
+  *     in order to apply this rule for all browser. The values {@link SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS} would be equivalent to { '*', SUBPIXEL_ROUNDING_OCCURRENCES.ALWAYS }.
+  *     The default is {@link SUBPIXEL_ROUNDING_OCCURRENCES.NEVER} for all browsers, for backward compatibility reason.
+  *
+  * @property {Number} [degrees=0]
+  *     Initial rotation.
+  *
+  * @property {Boolean} [flipped=false]
+  *     Initial flip state.
+  *
+  * @property {Boolean} [overlayPreserveContentDirection=true]
+  *     When the viewport is flipped (by pressing 'f'), the overlay is flipped using ScaleX.
+  *     Normally, this setting (default true) keeps the overlay's content readable by flipping it back.
+  *     To make the content flip with the overlay, set overlayPreserveContentDirection to false.
+  *
+  * @property {Number} [minZoomLevel=null]
+  *
+  * @property {Number} [maxZoomLevel=null]
+  *
+  * @property {Boolean} [homeFillsViewer=false]
+  *     Make the 'home' button fill the viewer and clip the image, instead
+  *     of fitting the image to the viewer and letterboxing.
+  *
+  * @property {Boolean} [panHorizontal=true]
+  *     Allow horizontal pan.
+  *
+  * @property {Boolean} [panVertical=true]
+  *     Allow vertical pan.
+  *
+  * @property {Boolean} [constrainDuringPan=false]
+  *
+  * @property {Boolean} [wrapHorizontal=false]
+  *     Set to true to force the image to wrap horizontally within the viewport.
+  *     Useful for maps or images representing the surface of a sphere or cylinder.
+  *
+  * @property {Boolean} [wrapVertical=false]
+  *     Set to true to force the image to wrap vertically within the viewport.
+  *     Useful for maps or images representing the surface of a sphere or cylinder.
+  *
+  * @property {Number} [minZoomImageRatio=0.9]
+  *     The minimum percentage ( expressed as a number between 0 and 1 ) of
+  *     the viewport height or width at which the zoom out will be constrained.
+  *     Setting it to 0, for example will allow you to zoom out infinity.
+  *
+  * @property {Number} [maxZoomPixelRatio=1.1]
+  *     The maximum ratio to allow a zoom-in to affect the highest level pixel
+  *     ratio. This can be set to Infinity to allow 'infinite' zooming into the
+  *     image though it is less effective visually if the HTML5 Canvas is not
+  *     available on the viewing device.
+  *
+  * @property {Number} [smoothTileEdgesMinZoom=1.1]
+  *     A zoom percentage ( where 1 is 100% ) of the highest resolution level.
+  *     When zoomed in beyond this value alternative compositing will be used to
+  *     smooth out the edges between tiles. This will have a performance impact.
+  *     Can be set to Infinity to turn it off.
+  *     Note: This setting is ignored on iOS devices due to a known bug (See {@link https://github.com/openseadragon/openseadragon/issues/952})
+  *
+  * @property {Boolean} [iOSDevice=?]
+  *     True if running on an iOS device, false otherwise.
+  *     Used to disable certain features that behave differently on iOS devices.
+  *
+  * @property {Boolean} [autoResize=true]
+  *     Set to false to prevent polling for viewer size changes. Useful for providing custom resize behavior.
+  *
+  * @property {Boolean} [preserveImageSizeOnResize=false]
+  *     Set to true to have the image size preserved when the viewer is resized. This requires autoResize=true (default).
+  *
+  * @property {Number} [minScrollDeltaTime=50]
+  *     Number of milliseconds between canvas-scroll events. This value helps normalize the rate of canvas-scroll
+  *     events between different devices, causing the faster devices to slow down enough to make the zoom control
+  *     more manageable.
+  *
+  * @property {Number} [rotationIncrement=90]
+  *     The number of degrees to rotate right or left when the rotate buttons or keyboard shortcuts are activated.
+  *
+  * @property {Number} [maxTilesPerFrame=1]
+  *     The number of tiles loaded per frame. As the frame rate of the client's machine is usually high (e.g., 50 fps),
+  *     one tile per frame should be a good choice. However, for large screens or lower frame rates, the number of
+  *     loaded tiles per frame can be adjusted here. Reasonable values might be 2 or 3 tiles per frame.
+  *     (Note that the actual frame rate is given by the client's browser and machine).
+  *
+  * @property {Number} [pixelsPerWheelLine=40]
+  *     For pixel-resolution scrolling devices, the number of pixels equal to one scroll line.
+  *
+  * @property {Number} [pixelsPerArrowPress=40]
+  *     The number of pixels viewport moves when an arrow key is pressed.
+  *
+  * @property {Number} [visibilityRatio=0.5]
+  *     The percentage ( as a number from 0 to 1 ) of the source image which
+  *     must be kept within the viewport.  If the image is dragged beyond that
+  *     limit, it will 'bounce' back until the minimum visibility ratio is
+  *     achieved.  Setting this to 0 and wrapHorizontal ( or wrapVertical ) to
+  *     true will provide the effect of an infinitely scrolling viewport.
+  *
+  * @property {Object} [viewportMargins={}]
+  *     Pushes the "home" region in from the sides by the specified amounts.
+  *     Possible subproperties (Numbers, in screen coordinates): left, top, right, bottom.
+  *
+  * @property {Number} [imageLoaderLimit=0]
+  *     The maximum number of image requests to make concurrently. By default
+  *     it is set to 0 allowing the browser to make the maximum number of
+  *     image requests in parallel as allowed by the browsers policy.
+  *
+  * @property {Number} [clickTimeThreshold=300]
+  *      The number of milliseconds within which a pointer down-up event combination
+  *      will be treated as a click gesture.
+  *
+  * @property {Number} [clickDistThreshold=5]
+  *      The maximum distance allowed between a pointer down event and a pointer up event
+  *      to be treated as a click gesture.
+  *
+  * @property {Number} [dblClickTimeThreshold=300]
+  *      The number of milliseconds within which two pointer down-up event combinations
+  *      will be treated as a double-click gesture.
+  *
+  * @property {Number} [dblClickDistThreshold=20]
+  *      The maximum distance allowed between two pointer click events
+  *      to be treated as a double-click gesture.
+  *
+  * @property {Number} [springStiffness=6.5]
+  *
+  * @property {Number} [animationTime=1.2]
+  *     Specifies the animation duration per each {@link OpenSeadragon.Spring}
+  *     which occur when the image is dragged, zoomed or rotated.
+  *
+  * @property {OpenSeadragon.GestureSettings} [gestureSettingsMouse]
+  *     Settings for gestures generated by a mouse pointer device. (See {@link OpenSeadragon.GestureSettings})
+  * @property {Boolean} [gestureSettingsMouse.dragToPan=true] - Pan on drag gesture
+  * @property {Boolean} [gestureSettingsMouse.scrollToZoom=true] - Zoom on scroll gesture
+  * @property {Boolean} [gestureSettingsMouse.clickToZoom=true] - Zoom on click gesture
+  * @property {Boolean} [gestureSettingsMouse.dblClickToZoom=false] - Zoom on double-click gesture. Note: If set to true
+  *     then clickToZoom should be set to false to prevent multiple zooms.
+  * @property {Boolean} [gestureSettingsMouse.dblClickDragToZoom=false] - Zoom on dragging through
+  * double-click gesture ( single click and next click to drag).  Note: If set to true
+  *     then clickToZoom should be set to false to prevent multiple zooms.
+  * @property {Boolean} [gestureSettingsMouse.pinchToZoom=false] - Zoom on pinch gesture
+  * @property {Boolean} [gestureSettingsMouse.zoomToRefPoint=true] - If zoomToRefPoint is true, the zoom is centered at the pointer position. Otherwise,
+  *     the zoom is centered at the canvas center.
+  * @property {Boolean} [gestureSettingsMouse.flickEnabled=false] - Enable flick gesture
+  * @property {Number} [gestureSettingsMouse.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
+  * @property {Number} [gestureSettingsMouse.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
+  * @property {Boolean} [gestureSettingsMouse.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
+  *
+  * @property {OpenSeadragon.GestureSettings} [gestureSettingsTouch]
+  *     Settings for gestures generated by a touch pointer device. (See {@link OpenSeadragon.GestureSettings})
+  * @property {Boolean} [gestureSettingsTouch.dragToPan=true] - Pan on drag gesture
+  * @property {Boolean} [gestureSettingsTouch.scrollToZoom=false] - Zoom on scroll gesture
+  * @property {Boolean} [gestureSettingsTouch.clickToZoom=false] - Zoom on click gesture
+  * @property {Boolean} [gestureSettingsTouch.dblClickToZoom=true] - Zoom on double-click gesture. Note: If set to true
+  *     then clickToZoom should be set to false to prevent multiple zooms.
+    * @property {Boolean} [gestureSettingsTouch.dblClickDragToZoom=true] - Zoom on dragging through
+  * double-click gesture ( single click and next click to drag).  Note: If set to true
+  *     then clickToZoom should be set to false to prevent multiple zooms.
+
+  * @property {Boolean} [gestureSettingsTouch.pinchToZoom=true] - Zoom on pinch gesture
+  * @property {Boolean} [gestureSettingsTouch.zoomToRefPoint=true] - If zoomToRefPoint is true, the zoom is centered at the pointer position. Otherwise,
+  *     the zoom is centered at the canvas center.
+  * @property {Boolean} [gestureSettingsTouch.flickEnabled=true] - Enable flick gesture
+  * @property {Number} [gestureSettingsTouch.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
+  * @property {Number} [gestureSettingsTouch.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
+  * @property {Boolean} [gestureSettingsTouch.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
+  *
+  * @property {OpenSeadragon.GestureSettings} [gestureSettingsPen]
+  *     Settings for gestures generated by a pen pointer device. (See {@link OpenSeadragon.GestureSettings})
+  * @property {Boolean} [gestureSettingsPen.dragToPan=true] - Pan on drag gesture
+  * @property {Boolean} [gestureSettingsPen.scrollToZoom=false] - Zoom on scroll gesture
+  * @property {Boolean} [gestureSettingsPen.clickToZoom=true] - Zoom on click gesture
+  * @property {Boolean} [gestureSettingsPen.dblClickToZoom=false] - Zoom on double-click gesture. Note: If set to true
+  *     then clickToZoom should be set to false to prevent multiple zooms.
+  * @property {Boolean} [gestureSettingsPen.pinchToZoom=false] - Zoom on pinch gesture
+  * @property {Boolean} [gestureSettingsPen.zoomToRefPoint=true] - If zoomToRefPoint is true, the zoom is centered at the pointer position. Otherwise,
+  *     the zoom is centered at the canvas center.
+  * @property {Boolean} [gestureSettingsPen.flickEnabled=false] - Enable flick gesture
+  * @property {Number} [gestureSettingsPen.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
+  * @property {Number} [gestureSettingsPen.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
+  * @property {Boolean} [gestureSettingsPen.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
+  *
+  * @property {OpenSeadragon.GestureSettings} [gestureSettingsUnknown]
+  *     Settings for gestures generated by unknown pointer devices. (See {@link OpenSeadragon.GestureSettings})
+  * @property {Boolean} [gestureSettingsUnknown.dragToPan=true] - Pan on drag gesture
+  * @property {Boolean} [gestureSettingsUnknown.scrollToZoom=true] - Zoom on scroll gesture
+  * @property {Boolean} [gestureSettingsUnknown.clickToZoom=false] - Zoom on click gesture
+  * @property {Boolean} [gestureSettingsUnknown.dblClickToZoom=true] - Zoom on double-click gesture. Note: If set to true
+  *     then clickToZoom should be set to false to prevent multiple zooms.
+  * @property {Boolean} [gestureSettingsUnknown.dblClickDragToZoom=false] - Zoom on dragging through
+  * double-click gesture ( single click and next click to drag).  Note: If set to true
+  *     then clickToZoom should be set to false to prevent multiple zooms.
+  * @property {Boolean} [gestureSettingsUnknown.pinchToZoom=true] - Zoom on pinch gesture
+  * @property {Boolean} [gestureSettingsUnknown.zoomToRefPoint=true] - If zoomToRefPoint is true, the zoom is centered at the pointer position. Otherwise,
+  *     the zoom is centered at the canvas center.
+  * @property {Boolean} [gestureSettingsUnknown.flickEnabled=true] - Enable flick gesture
+  * @property {Number} [gestureSettingsUnknown.flickMinSpeed=120] - If flickEnabled is true, the minimum speed to initiate a flick gesture (pixels-per-second)
+  * @property {Number} [gestureSettingsUnknown.flickMomentum=0.25] - If flickEnabled is true, the momentum factor for the flick gesture
+  * @property {Boolean} [gestureSettingsUnknown.pinchRotate=false] - If pinchRotate is true, the user will have the ability to rotate the image using their fingers.
+  *
+  * @property {Number} [zoomPerClick=2.0]
+  *     The "zoom distance" per mouse click or touch tap. <em><strong>Note:</strong> Setting this to 1.0 effectively disables the click-to-zoom feature (also see gestureSettings[Mouse|Touch|Pen].clickToZoom/dblClickToZoom).</em>
+  *
+  * @property {Number} [zoomPerScroll=1.2]
+  *     The "zoom distance" per mouse scroll or touch pinch. <em><strong>Note:</strong> Setting this to 1.0 effectively disables the mouse-wheel zoom feature (also see gestureSettings[Mouse|Touch|Pen].scrollToZoom}).</em>
+  *
+  * @property {Number} [zoomPerDblClickDrag=1.2]
+  *     The "zoom distance" per double-click mouse drag. <em><strong>Note:</strong> Setting this to 1.0 effectively disables the double-click-drag-to-Zoom feature (also see gestureSettings[Mouse|Touch|Pen].dblClickDragToZoom).</em>
+  *
+  * @property {Number} [zoomPerSecond=1.0]
+  *     Sets the zoom amount per second when zoomIn/zoomOut buttons are pressed and held.
+  *     The value is a factor of the current zoom, so 1.0 (the default) disables zooming when the zoomIn/zoomOut buttons
+  *     are held. Higher values will increase the rate of zoom when the zoomIn/zoomOut buttons are held. Note that values
+  *     < 1.0 will reverse the operation of the zoomIn/zoomOut buttons (zoomIn button will decrease the zoom, zoomOut will
+  *     increase the zoom).
+  *
+  * @property {Boolean} [showNavigator=false]
+  *     Set to true to make the navigator minimap appear.
+  *
+  * @property {Element} [navigatorElement=null]
+  *     The element to hold the navigator minimap.
+  *     If an element is specified, the Id option (see navigatorId) is ignored.
+  *     If no element nor ID is specified, a div element will be generated accordingly.
+  *
+  * @property {String} [navigatorId=navigator-GENERATED DATE]
+  *     The ID of a div to hold the navigator minimap.
+  *     If an ID is specified, the navigatorPosition, navigatorSizeRatio, navigatorMaintainSizeRatio, navigator[Top|Left|Height|Width] and navigatorAutoFade options will be ignored.
+  *     If an ID is not specified, a div element will be generated and placed on top of the main image.
+  *
+  * @property {String} [navigatorPosition='TOP_RIGHT']
+  *     Valid values are 'TOP_LEFT', 'TOP_RIGHT', 'BOTTOM_LEFT', 'BOTTOM_RIGHT', or 'ABSOLUTE'.<br>
+  *     If 'ABSOLUTE' is specified, then navigator[Top|Left|Height|Width] determines the size and position of the navigator minimap in the viewer, and navigatorSizeRatio and navigatorMaintainSizeRatio are ignored.<br>
+  *     For 'TOP_LEFT', 'TOP_RIGHT', 'BOTTOM_LEFT', and 'BOTTOM_RIGHT', the navigatorSizeRatio or navigator[Height|Width] values determine the size of the navigator minimap.
+  *
+  * @property {Number} [navigatorSizeRatio=0.2]
+  *     Ratio of navigator size to viewer size. Ignored if navigator[Height|Width] are specified.
+  *
+  * @property {Boolean} [navigatorMaintainSizeRatio=false]
+  *     If true, the navigator minimap is resized (using navigatorSizeRatio) when the viewer size changes.
+  *
+  * @property {Number|String} [navigatorTop=null]
+  *     Specifies the location of the navigator minimap (see navigatorPosition).
+  *
+  * @property {Number|String} [navigatorLeft=null]
+  *     Specifies the location of the navigator minimap (see navigatorPosition).
+  *
+  * @property {Number|String} [navigatorHeight=null]
+  *     Specifies the size of the navigator minimap (see navigatorPosition).
+  *     If specified, navigatorSizeRatio and navigatorMaintainSizeRatio are ignored.
+  *
+  * @property {Number|String} [navigatorWidth=null]
+  *     Specifies the size of the navigator minimap (see navigatorPosition).
+  *     If specified, navigatorSizeRatio and navigatorMaintainSizeRatio are ignored.
+  *
+  * @property {Boolean} [navigatorAutoResize=true]
+  *     Set to false to prevent polling for navigator size changes. Useful for providing custom resize behavior.
+  *     Setting to false can also improve performance when the navigator is configured to a fixed size.
+  *
+  * @property {Boolean} [navigatorAutoFade=true]
+  *     If the user stops interacting with the viewport, fade the navigator minimap.
+  *     Setting to false will make the navigator minimap always visible.
+  *
+  * @property {Boolean} [navigatorRotate=true]
+  *     If true, the navigator will be rotated together with the viewer.
+  *
+  * @property {String} [navigatorBackground='#000']
+  *     Specifies the background color of the navigator minimap
+  *
+  * @property {Number} [navigatorOpacity=0.8]
+  *     Specifies the opacity of the navigator minimap.
+  *
+  * @property {String} [navigatorBorderColor='#555']
+  *     Specifies the border color of the navigator minimap
+  *
+  * @property {String} [navigatorDisplayRegionColor='#900']
+  *     Specifies the border color of the display region rectangle of the navigator minimap
+  *
+  * @property {Number} [controlsFadeDelay=2000]
+  *     The number of milliseconds to wait once the user has stopped interacting
+  *     with the interface before beginning to fade the controls. Assumes
+  *     showNavigationControl and autoHideControls are both true.
+  *
+  * @property {Number} [controlsFadeLength=1500]
+  *     The number of milliseconds to animate the controls fading out.
+  *
+  * @property {Number} [maxImageCacheCount=200]
+  *     The max number of images we should keep in memory (per drawer).
+  *
+  * @property {Number} [timeout=30000]
+  *     The max number of milliseconds that an image job may take to complete.
+  *
+  * @property {Number} [tileRetryMax=0]
+  *     The max number of retries when a tile download fails. By default it's 0, so retries are disabled.
+  *
+  * @property {Number} [tileRetryDelay=2500]
+  *     Milliseconds to wait after each tile retry if tileRetryMax is set.
+  *
+  * @property {Boolean} [useCanvas=true]
+  *     Deprecated. Use the `drawer` option to specify preferred renderer.
+  *
+  * @property {Number} [minPixelRatio=0.5]
+  *     The higher the minPixelRatio, the lower the quality of the image that
+  *     is considered sufficient to stop rendering a given zoom level.  For
+  *     example, if you are targeting mobile devices with less bandwidth you may
+  *     try setting this to 1.5 or higher.
+  *
+  * @property {Boolean} [mouseNavEnabled=true]
+  *     Is the user able to interact with the image via mouse or touch. Default
+  *     interactions include draging the image in a plane, and zooming in toward
+  *     and away from the image.
+  *
+  * @property {Boolean} [showNavigationControl=true]
+  *     Set to false to prevent the appearance of the default navigation controls.<br>
+  *     Note that if set to false, the customs buttons set by the options
+  *     zoomInButton, zoomOutButton etc, are rendered inactive.
+  *
+  * @property {OpenSeadragon.ControlAnchor} [navigationControlAnchor=TOP_LEFT]
+  *     Placement of the default navigation controls.
+  *     To set the placement of the sequence controls, see the
+  *     sequenceControlAnchor option.
+  *
+  * @property {Boolean} [showZoomControl=true]
+  *     If true then + and - buttons to zoom in and out are displayed.<br>
+  *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
+  *     this setting when set to false.
+  *
+  * @property {Boolean} [showHomeControl=true]
+  *     If true then the 'Go home' button is displayed to go back to the original
+  *     zoom and pan.<br>
+  *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
+  *     this setting when set to false.
+  *
+  * @property {Boolean} [showFullPageControl=true]
+  *     If true then the 'Toggle full page' button is displayed to switch
+  *     between full page and normal mode.<br>
+  *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
+  *     this setting when set to false.
+  *
+  * @property {Boolean} [showRotationControl=false]
+  *     If true then the rotate left/right controls will be displayed as part of the
+  *     standard controls. This is also subject to the browser support for rotate
+  *     (e.g. viewer.drawer.canRotate()).<br>
+  *     Note: {@link OpenSeadragon.Options.showNavigationControl} is overriding
+  *     this setting when set to false.
+  *
+  * @property {Boolean} [showFlipControl=false]
+  *     If true then the flip controls will be displayed as part of the
+  *     standard controls.
+  *
+  * @property {Boolean} [showSequenceControl=true]
+  *     If sequenceMode is true, then provide buttons for navigating forward and
+  *     backward through the images.
+  *
+  * @property {OpenSeadragon.ControlAnchor} [sequenceControlAnchor=TOP_LEFT]
+  *     Placement of the default sequence controls.
+  *
+  * @property {Boolean} [navPrevNextWrap=false]
+  *     If true then the 'previous' button will wrap to the last image when
+  *     viewing the first image and the 'next' button will wrap to the first
+  *     image when viewing the last image.
+  *
+  *@property {String|Element} zoomInButton
+  *     Set the id or element of the custom 'Zoom in' button to use.
+  *     This is useful to have a custom button anywhere in the web page.<br>
+  *     To only change the button images, consider using
+  *     {@link OpenSeadragon.Options.navImages}
+  *
+  * @property {String|Element} zoomOutButton
+  *     Set the id or element of the custom 'Zoom out' button to use.
+  *     This is useful to have a custom button anywhere in the web page.<br>
+  *     To only change the button images, consider using
+  *     {@link OpenSeadragon.Options.navImages}
+  *
+  * @property {String|Element} homeButton
+  *     Set the id or element of the custom 'Go home' button to use.
+  *     This is useful to have a custom button anywhere in the web page.<br>
+  *     To only change the button images, consider using
+  *     {@link OpenSeadragon.Options.navImages}
+  *
+  * @property {String|Element} fullPageButton
+  *     Set the id or element of the custom 'Toggle full page' button to use.
+  *     This is useful to have a custom button anywhere in the web page.<br>
+  *     To only change the button images, consider using
+  *     {@link OpenSeadragon.Options.navImages}
+  *
+  * @property {String|Element} rotateLeftButton
+  *     Set the id or element of the custom 'Rotate left' button to use.
+  *     This is useful to have a custom button anywhere in the web page.<br>
+  *     To only change the button images, consider using
+  *     {@link OpenSeadragon.Options.navImages}
+  *
+  * @property {String|Element} rotateRightButton
+  *     Set the id or element of the custom 'Rotate right' button to use.
+  *     This is useful to have a custom button anywhere in the web page.<br>
+  *     To only change the button images, consider using
+  *     {@link OpenSeadragon.Options.navImages}
+  *
+  * @property {String|Element} previousButton
+  *     Set the id or element of the custom 'Previous page' button to use.
+  *     This is useful to have a custom button anywhere in the web page.<br>
+  *     To only change the button images, consider using
+  *     {@link OpenSeadragon.Options.navImages}
+  *
+  * @property {String|Element} nextButton
+  *     Set the id or element of the custom 'Next page' button to use.
+  *     This is useful to have a custom button anywhere in the web page.<br>
+  *     To only change the button images, consider using
+  *     {@link OpenSeadragon.Options.navImages}
+  *
+  * @property {Boolean} [sequenceMode=false]
+  *     Set to true to have the viewer treat your tilesources as a sequence of images to
+  *     be opened one at a time rather than all at once.
+  *
+  * @property {Number} [initialPage=0]
+  *     If sequenceMode is true, display this page initially.
+  *
+  * @property {Boolean} [preserveViewport=false]
+  *     If sequenceMode is true, then normally navigating through each image resets the
+  *     viewport to 'home' position.  If preserveViewport is set to true, then the viewport
+  *     position is preserved when navigating between images in the sequence.
+  *
+  * @property {Boolean} [preserveOverlays=false]
+  *     If sequenceMode is true, then normally navigating through each image
+  *     resets the overlays.
+  *     If preserveOverlays is set to true, then the overlays added with {@link OpenSeadragon.Viewer#addOverlay}
+  *     are preserved when navigating between images in the sequence.
+  *     Note: setting preserveOverlays overrides any overlays specified in the global
+  *     "overlays" option for the Viewer. It's also not compatible with specifying
+  *     per-tileSource overlays via the options, as those overlays will persist
+  *     even after the tileSource is closed.
+  *
+  * @property {Boolean} [showReferenceStrip=false]
+  *     If sequenceMode is true, then display a scrolling strip of image thumbnails for
+  *     navigating through the images.
+  *
+  * @property {String} [referenceStripScroll='horizontal']
+  *
+  * @property {Element} [referenceStripElement=null]
+  *
+  * @property {Number} [referenceStripHeight=null]
+  *
+  * @property {Number} [referenceStripWidth=null]
+  *
+  * @property {String} [referenceStripPosition='BOTTOM_LEFT']
+  *
+  * @property {Number} [referenceStripSizeRatio=0.2]
+  *
+  * @property {Boolean} [collectionMode=false]
+  *     Set to true to have the viewer arrange your TiledImages in a grid or line.
+  *
+  * @property {Number} [collectionRows=3]
+  *     If collectionMode is true, specifies how many rows the grid should have. Use 1 to make a line.
+  *     If collectionLayout is 'vertical', specifies how many columns instead.
+  *
+  * @property {Number} [collectionColumns=0]
+  *     If collectionMode is true, specifies how many columns the grid should have. Use 1 to make a line.
+  *     If collectionLayout is 'vertical', specifies how many rows instead. Ignored if collectionRows is not set to a falsy value.
+  *
+  * @property {String} [collectionLayout='horizontal']
+  *     If collectionMode is true, specifies whether to arrange vertically or horizontally.
+  *
+  * @property {Number} [collectionTileSize=800]
+  *     If collectionMode is true, specifies the size, in viewport coordinates, for each TiledImage to fit into.
+  *     The TiledImage will be centered within a square of the specified size.
+  *
+  * @property {Number} [collectionTileMargin=80]
+  *     If collectionMode is true, specifies the margin, in viewport coordinates, between each TiledImage.
+  *
+  * @property {String|Boolean} [crossOriginPolicy=false]
+  *     Valid values are 'Anonymous', 'use-credentials', and false. If false, canvas requests will
+  *     not use CORS, and the canvas will be tainted.
+  *
+  * @property {Boolean} [ajaxWithCredentials=false]
+  *     Whether to set the withCredentials XHR flag for AJAX requests.
+  *     Note that this can be overridden at the {@link OpenSeadragon.TileSource} level.
+  *
+  * @property {Boolean} [loadTilesWithAjax=false]
+  *     Whether to load tile data using AJAX requests.
+  *     Note that this can be overridden at the {@link OpenSeadragon.TileSource} level.
+  *
+  * @property {Object} [ajaxHeaders={}]
+  *     A set of headers to include when making AJAX requests for tile sources or tiles.
+  *
+  * @property {Boolean} [splitHashDataForPost=false]
+  *     Allows to treat _first_ hash ('#') symbol as a separator for POST data:
+  *     URL to be opened by a {@link OpenSeadragon.TileSource} can thus look like: http://some.url#postdata=here.
+  *     The whole URL is used to fetch image info metadata and it is then split to 'http://some.url' and
+  *     'postdata=here'; post data is given to the {@link OpenSeadragon.TileSource} of the choice and can be further
+  *     used within tile requests (see TileSource methods).
+  *     NOTE: {@link OpenSeadragon.TileSource.prototype.configure} return value should contain the post data
+  *     if you want to use it later - so that it is given to your constructor later.
+  *     NOTE: usually, post data is expected to be ampersand-separated (just like GET parameters), and is NOT USED
+  *     to fetch tile image data unless explicitly programmed, or if loadTilesWithAjax=false 4
+  *     (but it is still used for the initial image info request).
+  *     NOTE: passing POST data from URL by this feature only supports string values, however,
+  *     TileSource can send any data using POST as long as the header is correct
+  *     (@see OpenSeadragon.TileSource.prototype.getTilePostData)
+  */
+
+ /**
+  * Settings for gestures generated by a pointer device.
+  *
+  * @typedef {Object} GestureSettings
+  * @memberof OpenSeadragon
+  *
+  * @property {Boolean} dragToPan
+  *     Set to false to disable panning on drag gestures.
+  *
+  * @property {Boolean} scrollToZoom
+  *     Set to false to disable zooming on scroll gestures.
+  *
+  * @property {Boolean} clickToZoom
+  *     Set to false to disable zooming on click gestures.
+  *
+  * @property {Boolean} dblClickToZoom
+  *     Set to false to disable zooming on double-click gestures. Note: If set to true
+  *     then clickToZoom should be set to false to prevent multiple zooms.
+  *
+  * @property {Boolean} pinchToZoom
+  *     Set to false to disable zooming on pinch gestures.
+  *
+  * @property {Boolean} flickEnabled
+  *     Set to false to disable the kinetic panning effect (flick) at the end of a drag gesture.
+  *
+  * @property {Number} flickMinSpeed
+  *     If flickEnabled is true, the minimum speed (in pixels-per-second) required to cause the kinetic panning effect (flick) at the end of a drag gesture.
+  *
+  * @property {Number} flickMomentum
+  *     If flickEnabled is true, a constant multiplied by the velocity to determine the distance of the kinetic panning effect (flick) at the end of a drag gesture.
+  *     A larger value will make the flick feel "lighter", while a smaller value will make the flick feel "heavier".
+  *     Note: springStiffness and animationTime also affect the "spring" used to stop the flick animation.
+  *
+  */
+
+ /**
+  * @typedef {Object} DrawerOptions
+  * @memberof OpenSeadragon
+  * @property {Object} webgl - options if the WebGLDrawer is used. No options are currently supported.
+  * @property {Object} canvas - options if the CanvasDrawer is used. No options are currently supported.
+  * @property {Object} html - options if the HTMLDrawer is used. No options are currently supported.
+  * @property {Object} custom - options if a custom drawer is used. No options are currently supported.
+  */
+```

--- a/source/Pict-Section-OpenSeaDragon.js
+++ b/source/Pict-Section-OpenSeaDragon.js
@@ -1,0 +1,464 @@
+const libPictViewClass = require('pict-view');
+
+const html = String.raw;
+const css = String.raw;
+
+const default_configuration = {
+	"RenderOnLoad": true,
+
+	"DefaultRenderable": "OpenSeaDragon-Wrap",
+	"DefaultDestinationAddress": "#OpenSeaDragon-Container-Div",
+	"EnableAnnotation": false,
+	"PrefixUrl": '/',
+	"TileSources": {},
+	"ViewAddress": 'OSDSection',
+	"Colors": {
+		"red": "red",
+		"green": "green",
+		"blue": "blue"
+	},
+	"Annotations": [],
+
+	"Templates": [
+		{
+			"Hash": "OpenSeaDragon-Container",
+			"Template": html`
+				<div style="width: 100%; height: 100%; display: flex; flex-direction: row;" id="OSD-Containers-Wrapper">
+					<div style="width: 100%; height: 100%;" id="OSD-Container-Left">
+						<div id="OpenSeaDragon-Element" style="margin-left: 20px; margin-right: 5px; width: calc(100% - 25px); height: 100%;"></div>
+						<div id="OSD-Toolbar" class="osd-height-zero osd-toolbar">
+							<div id="DrawingToolbar" style="min-width: 320px" ></div>
+							<div id="ColorPickerToolbar" style="display: flex; flex-direction: row;"></div>
+						</div>
+					</div>
+					<div style="width: 20%; height: 100%;" class="osd-width-zero" id="OSD-Container-Right">
+						<div id="OSD-Scrollable-Comments" class="osd-scrollable-comments"></div>
+					</div>
+				</div>
+				<style id="ColorOverrides"></style>
+				<style id="SelectedColorOverride"></style>
+				<style id="OSDGeneralStyling">
+					.osd-scrollable-comments {
+						height: 100%;
+						width: 100%;
+						overflow-y: scroll;
+					}
+					.osd-color-active {
+						background-color: rgba(0, 0, 0, 0.3) !important;
+					}
+					.osd-with-annotations {
+						height: calc(100% - 55px) !important;
+					}
+					.osd-height-zero {
+						height: 0px !important;
+					}
+					.osd-width-zero {
+						width: 0px !important;
+					}
+					.color-button-class {
+						margin:4px 4px 4px 0;
+						background-color: transparent;
+						cursor: pointer;
+						border-radius: 4px;
+						padding: 8px;
+						width: 45px;
+						height: 45px;
+						border: 0px;
+					}
+					.color-button-class:hover {
+						background-color:rgba(0,0,0,0.05);
+					}
+					.osd-toolbar {
+						height: 55px;
+						width: 100%;
+						display: flex;
+						flex-direction: row;
+						justify-content: space-between;
+					}
+					.osd-annotations-panel-open {
+						width: 80% !important
+					}
+				</style>
+			`
+		}
+	],
+
+	"Renderables": [
+		{
+			"RenderableHash": "OpenSeaDragon-Wrap",
+			"TemplateHash": "OpenSeaDragon-Container",
+			"DestinationAddress": "#OpenSeaDragon-Container-Div",
+			"RenderType": "replace"
+		}
+	],
+
+	"TargetElementAddress": "#OpenSeaDragon-Container-Div"
+};
+
+class PictSectionOpenSeaDragon extends libPictViewClass
+{
+	constructor(pFable, pOptions, pServiceHash)
+	{
+		let tmpOptions = Object.assign({}, default_configuration, pOptions);
+
+		super(pFable, tmpOptions, pServiceHash);
+
+		this.initialRenderComplete = false;
+	}
+
+	onBeforeInitialize()
+	{
+		super.onBeforeInitialize();
+
+		this.targetElementAddress = false;
+	}
+
+	onAfterRender()
+	{
+		if (!this.initialRenderComplete)
+		{
+			this.onAfterInitialRender();
+			this.initialRenderComplete = true;
+		}
+	}
+
+	onAfterInitialRender()
+	{
+
+		let tmpTargetElementSet = this.services.ContentAssignment.getElement('#OpenSeaDragon-Element');
+		if (tmpTargetElementSet.length < 1)
+		{
+			this.log.error(`Could not find target element [#OpenSeaDragon-Element] for OpenSeaDragon!  Rendering won't function properly.`);
+			this.targetElement = false;
+			return false;
+		}
+		else
+		{
+			this.targetElement = tmpTargetElementSet[0];
+		}
+		let tmpToolbarElementSet = this.services.ContentAssignment.getElement('#DrawingToolbar');
+		if (tmpToolbarElementSet.length < 1)
+		{
+			this.log.error(`Could not find target element [#DrawingToolbar] for Annotator Toolbar!  Annotations won't function properly.`);
+			this.toolbarElement = false;
+			return false;
+		}
+		else
+		{
+			this.toolbarElement = tmpToolbarElementSet[0];
+		}
+
+		// Settings for configuring OpenSeaDragon.
+		this.osdSettings = 
+		{
+			element: this.targetElement,
+			prefixUrl: this.options.PrefixUrl,
+			tileSources: this.options.TileSources
+		};
+
+		// Settings for configuring Annotorious.
+		this.annoSettings = {
+			allowEmpty: true
+		};
+
+		// Color formatter for Annotorious. Works with the styleClass attribute and the color class system which is config based.
+		this.format = (annotation) => {
+			return 'pict-osd-' + (annotation?.underlying?.target?.styleClass || this.color || 'red');
+		};
+
+		this.customConfigureViewerSettings();
+
+		// Instantiate the OpenSeaDragon element.
+		this.viewer = OpenSeadragon(this.osdSettings);
+
+		// Inject a stylesheet based on the set of colors passed into the component.
+		let colorStyles = '';
+		if (Object.keys(this.options?.Colors)?.length)
+		{
+			this.colorSet = this.options.Colors;
+			for (let color of Object.keys(this.colorSet))
+			{
+				colorStyles += css`
+					.pict-osd-${ color } > * {
+						stroke: ${ this.colorSet[color] } !important;
+						stroke-width: 2 !important;
+					}
+				`;
+			}
+		}
+		else
+		{
+			this.assignColor('red');
+			colorStyles += css`
+				.pict-osd-red > * {
+					stroke: red !important;
+					stroke-width: 2 !important;
+				}
+			`;
+		}
+		this.pict.ContentAssignment.assignContent('#ColorOverrides', colorStyles);
+
+		// We only need to instantiate Annotorious if a set of annotations were passed in, or annotation editing is enabled.
+		const editingEnabled = this.options.EnableAnnotation && this.toolbarElement;
+		if (editingEnabled || this.options.Annotations?.length)
+		{
+			// Instantiate Annotorious.
+			this.annotator = OpenSeadragon.Annotorious(this.viewer, this.annoSettings);
+
+			// Apply the custom color formatter.
+			this.annotator.formatters = [this.format];
+
+			// Instantiate Annotorious Plugins.
+			Annotorious.SelectorPack(this.annotator, 
+			{
+				tools: ['circle', 'ellipse', 'rect', 'freehand', 'polygon', 'line']
+			});
+			Annotorious.BetterPolygon(this.annotator);
+
+			// If editing is enabled, reflow the ui to include the editing toolbar.
+			if (editingEnabled)
+			{
+				this.pict.ContentAssignment.addClass('#OpenSeaDragon-Element', 'osd-with-annotations');
+				this.pict.ContentAssignment.removeClass('#OSD-Toolbar', 'osd-height-zero');
+				Annotorious.Toolbar(this.annotator, this.toolbarElement, { withMouse: true, withTooltip:false });
+			}
+
+			//Inject any annotations passed via config.
+			if (this.options.Annotations?.length)
+			{
+				for (let a of this.options.Annotations)
+				{
+					this.annotator.addAnnotation(a);
+				}
+				this.updateAnnotationsPanel();
+			}
+
+			// Apply hooks for the annotation events.
+			this.annotator.on('createAnnotation', (annotation, overrideID) => { this.annotationCreationHook(annotation, overrideID) });
+			this.annotator.on('selectAnnotation', (annotation, element) => { this.annotationSelectionHook(annotation, element); });
+			this.annotator.on('updateAnnotation', (annotation, previousState) => { this.annotationUpdateHook(annotation, previousState); });
+			this.annotator.on('deleteAnnotation', (annotation) => { this.annotationDeleteHook(annotation); });
+
+			// If a custom color set was passed via config, add those custom colors to the toolbar if editing is enabled.
+			if (this.colorSet && editingEnabled)
+			{
+				let colorSelectorTemplate = ``;
+				for (let color of Object.keys(this.colorSet))
+				{
+					colorSelectorTemplate += html`
+						<button type="button" class="color-button-class" onclick="_Pict.views.${ this.options.ViewAddress || 'OSDSection' }.assignColor('${ color }')" id="ColorSelector${ color }" style="color: ${ this.colorSet[color] };">&#11044;</button>
+					`;
+				}
+				this.pict.ContentAssignment.assignContent('#ColorPickerToolbar', `
+					${ colorSelectorTemplate }
+				`);
+				this.assignColor(Object.keys(this.colorSet)[0]);
+			}
+			else
+			{
+				this.assignColor('red');
+			}
+		}
+	}
+
+	/**
+	 * This is expected to be overloaded with anything that needs to be added to the OpenSeaDragon configuration.
+	 */
+	customConfigureViewerSettings ()
+	{
+		// This can be overloaded to tweak this.osdSettings and this.annoSettings.
+	}
+
+	// Sets the current drawing color for annotations.
+	assignColor (color)
+	{
+		this.color = color;
+		if (this.colorSet)
+		{
+			for (let tempColor of Object.keys(this.colorSet))
+			{
+				this.pict.ContentAssignment.removeClass(`#ColorSelector${ tempColor }`, 'osd-color-active');
+			}
+		}
+
+		// Set the active color in the toolbar.
+		this.pict.ContentAssignment.addClass(`#ColorSelector${ color }`, 'osd-color-active');
+
+		// Override the annotator drawing styles based on the selected color.
+		this.pict.ContentAssignment.assignContent('#SelectedColorOverride', css`
+			.a9s-annotation.editable.selected > g > * {
+				stroke: ${ this.colorSet?.[color] || 'red' } !important;
+				stroke-width: 2 !important;
+			}
+			.a9s-selection > g > path {
+				stroke: ${ this.colorSet?.[color] || 'red' } !important;
+				stroke-width: 2 !important;
+			}
+			.a9s-selection > * {
+				stroke: ${ this.colorSet?.[color] || 'red' } !important;
+				stroke-width: 2 !important;
+			}
+		`);
+	}
+
+	// Hook that runs when an annotation gets selected. By default, this just stores the style of the annotation element as part of the annotation.
+	annotationCreationHook (annotation, overrideID)
+	{
+		if (annotation?.target){
+			annotation.stylesheet = 
+			{
+				"type": "CssStylesheet",
+				"value": css`
+					.${ this.color } { 
+						stroke: ${ this.colorSet?.[this.color] } !important;
+						stroke-width: 2 !important; 
+					}
+				`
+			};
+			annotation.target.styleClass = this.color;
+		}
+		this.updateAnnotationsPanel();
+	}
+
+	// Hook that runs when an annotation gets selected. By default, this just sets the current color to whatever the selected annotation is.
+	annotationSelectionHook (annotation, element)
+	{
+		this.assignColor(annotation?.target?.styleClass || 'red');
+	}
+
+	// Hook that runs when an annotation gets updated. By default this is used for updating the state of the comments side bar.
+	annotationUpdateHook (annotation, previousState)
+	{
+		this.updateAnnotationsPanel();
+	}
+
+	// Hook that runs when an annotation gets delete. By default this is used for updating the state of the comments side bar.
+	annotationDeleteHook (annotation)
+	{
+		this.updateAnnotationsPanel(annotationSet);
+	}
+
+	// Update the annotations side panel to include any annotation comments/tags, should be called anytime the annotation list gets changed (create/update/delete).
+	updateAnnotationsPanel(annotations) {
+		const annotationSet = annotations || this.captureAnnotations();
+
+		this.pict.ContentAssignment.assignContent('#OSD-Scrollable-Comments', '');
+		let commentsTemplate = '';
+
+		// Loop through the annotations and add any with comments or tags to the panel ui.
+		for (let a of annotationSet)
+		{
+			let bodyCommentTemplate = '';
+			let bodyTagTemplate = '';
+			for (let b of a.body)
+			{
+				if (b.purpose === 'commenting')
+				{
+					bodyCommentTemplate += html`
+						<div class="r6o-editable-text" style="border-top: 1px solid lightgrey; max-height: fit-content;">
+							${ b.value }
+						</div>
+					`;
+				}
+				if (b.purpose === 'tagging')
+				{
+					bodyTagTemplate += html`
+						<li>
+							<span class="r6o-label">
+								${ b.value }
+							</span>
+						</li>
+					`;
+				}
+			}
+			if (bodyCommentTemplate || bodyTagTemplate)
+			{
+				if (bodyCommentTemplate)
+				{
+					bodyCommentTemplate = html`
+						<div disabled class="r6o-widget comment">
+							${ bodyCommentTemplate }
+						</div>
+					`;
+				}
+				if (bodyTagTemplate)
+				{
+					bodyTagTemplate = html`
+						<div class="r6o-widget r6o-tag">
+							<ul class="r6o-taglist">
+								${ bodyTagTemplate }
+							</ul>
+						</div>
+					`;
+				}
+				commentsTemplate += html`
+					<div class="r6o-editor r6o-arrow-top r6o-arrow-left pushed right" onclick="_Pict.views.${ this.options.ViewAddress || 'OSDSection' }.selectAnnotation('${ a.id }')" style="z-index: auto; line-height: normal; cursor: pointer; max-width: 100%; opacity: 1; position: relative !important; margin: 10px 0px 10px 0px;">
+						<div class="r6o-editor-inner" style="-webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none; border-radius: 4px; border: 1px solid lightgrey;">
+							${ bodyCommentTemplate }
+							${ bodyTagTemplate }
+						</div>
+					</div>
+				`;
+			}
+		}
+
+		// If anything was added to the panel template, inject it back into the section and ensure the panel is open.
+		if (commentsTemplate)
+		{
+			this.pict.ContentAssignment.assignContent('#OSD-Scrollable-Comments', commentsTemplate);
+			this.pict.ContentAssignment.removeClass('#OSD-Container-Right', 'osd-width-zero');
+			this.pict.ContentAssignment.addClass('#OSD-Container-Left', 'osd-annotations-panel-open');
+		}
+		else
+		{
+			// Otherwise, close the panel ui.
+			this.pict.ContentAssignment.addClass('#OSD-Container-Right', 'osd-width-zero');
+			this.pict.ContentAssignment.removeClass('#OSD-Container-Left', 'osd-annotations-panel-open');
+		}
+	}
+
+	// Passes an annotation selection event onto the annotator plus does some extra handling to scroll it into view.
+	selectAnnotation(id)
+	{
+		this.annotator.selectAnnotation(id);
+		for (let a of this.captureAnnotations())
+		{
+			if (a.id === id)
+			{
+				this.annotationSelectionHook(a);
+			}
+		}
+
+		// Pan/Zoom the OSD controller to the annotation that is being selected.
+		this.annotator.fitBounds(id);
+	}
+
+	/*
+	 * Captures the current viewport relative to the overall image.
+	 */
+	captureViewport ()
+	{
+		if (this.viewer){
+			return this.viewer.viewport.getBounds();
+		}
+		this.log.error('OpenSeaDragon is not initialized for some reason, giving back null.');
+		return null;
+	}
+
+	/*
+	 * Captures the annotation objects for the currently annotated image.
+	 */
+	captureAnnotations ()
+	{
+		if (this.annotator){
+			return this.annotator.getAnnotations();
+		}
+		return [];
+	}
+		
+}
+
+module.exports = PictSectionOpenSeaDragon;
+
+module.exports.default_configuration = default_configuration;
+


### PR DESCRIPTION
Initial commit of the library and an example application using the library.
Some of the main configurable behaviors:
-EnableAnnotation - Turns on editing and adds the annotation toolbar.
-Annotations - Can pass in existing annotations, if EnableAnnotation is false they will be read only (clicking a comment or tag in the right hand bar will still put it into focus.
-TileSources: The tile source object to use for OpenSeaDragon. should work with any valid tile source.
-PrefixURL: The url location of the OpenSeaDragon icon images, is used by OSD to load its image icons.
-Colors: A map of color names and their css values. Can pass as many or as few as you want and they will be automatically added to the editing toolbar.
-ViewAddress: the global address of the component instance under the _Pict object, used for click events.
