### PR TITLE
osd: refocus viewport on selection for visibility

### DIFF
--- a/example_applications/photo_example/README-SimpleForm.md
+++ b/example_applications/photo_example/README-SimpleForm.md
@@ -1,6 +1,6 @@
 # Minimum Viable Forms Application
 
 To run this, install dependencies in the root of the repository with a `npm install`
-and then navigate to this folder and run `npm run build` to build the dist files
+and then navigate to this folder and run another `npm install` followed by `npm run build` to build the dist files
 (which are not checked in).  Then, you should be able to open index.html in the dist
 foder from your favorite browser.

--- a/example_applications/photo_example/html/index.html
+++ b/example_applications/photo_example/html/index.html
@@ -4,7 +4,7 @@
 		<title>Simple.</title>
 		<style id="PICT-CSS"></style>
 		<link href="annotorious.min.css" rel="stylesheet">
-		<script src="./pict.min.js" type="text/javascript"></script>
+		<script src="../dist/pict.min.js" type="text/javascript"></script>
 		<script type="text/javascript">Pict.safeOnDocumentReady(() => { Pict.safeLoadPictApplication(SimpleImageviewer, 1)});</script>
 	</head>
 	<body>
@@ -12,11 +12,11 @@
 			<div id="OpenSeaDragon-Container-Div" style="width:800px; height:600px;"></div>
 			<div id="OpenSeaDragonAnnotationSelector-Container-Div" style="width:200px; height:600px;"></div>
 		</div>
-		<script src="./openseadragon.3.0.0.min.js" type="text/javascript"></script>
-		<script src="./openseadragon-annotorious.min.js" type="text/javascript"></script>
-		<script src="./annotorious-toolbar.min.js" type="text/javascript"></script>
-		<script src="./annotorious-selector-pack.js" type="text/javascript"></script>
-		<script src="./annotorious-better-polygon.js" type="text/javascript"></script>
-		<script src="./simple_imageviewer.min.js" type="text/javascript"></script>
+		<script src="../dist/openseadragon.3.0.0.min.js" type="text/javascript"></script>
+		<script src="../dist/openseadragon-annotorious.min.js" type="text/javascript"></script>
+		<script src="../dist/annotorious-toolbar.min.js" type="text/javascript"></script>
+		<script src="../dist/annotorious-selector-pack.js" type="text/javascript"></script>
+		<script src="../dist/annotorious-better-polygon.js" type="text/javascript"></script>
+		<script src="../dist/simple_imageviewer.min.js" type="text/javascript"></script>
 	</body>
 </html>

--- a/example_applications/photo_example/html/index.html
+++ b/example_applications/photo_example/html/index.html
@@ -4,7 +4,7 @@
 		<title>Simple.</title>
 		<style id="PICT-CSS"></style>
 		<link href="annotorious.min.css" rel="stylesheet">
-		<script src="../dist/pict.min.js" type="text/javascript"></script>
+		<script src="./pict.min.js" type="text/javascript"></script>
 		<script type="text/javascript">Pict.safeOnDocumentReady(() => { Pict.safeLoadPictApplication(SimpleImageviewer, 1)});</script>
 	</head>
 	<body>
@@ -12,11 +12,11 @@
 			<div id="OpenSeaDragon-Container-Div" style="width:800px; height:600px;"></div>
 			<div id="OpenSeaDragonAnnotationSelector-Container-Div" style="width:200px; height:600px;"></div>
 		</div>
-		<script src="../dist/openseadragon.3.0.0.min.js" type="text/javascript"></script>
-		<script src="../dist/openseadragon-annotorious.min.js" type="text/javascript"></script>
-		<script src="../dist/annotorious-toolbar.min.js" type="text/javascript"></script>
-		<script src="../dist/annotorious-selector-pack.js" type="text/javascript"></script>
-		<script src="../dist/annotorious-better-polygon.js" type="text/javascript"></script>
-		<script src="../dist/simple_imageviewer.min.js" type="text/javascript"></script>
+		<script src="./openseadragon.3.0.0.min.js" type="text/javascript"></script>
+		<script src="./openseadragon-annotorious.min.js" type="text/javascript"></script>
+		<script src="./annotorious-toolbar.min.js" type="text/javascript"></script>
+		<script src="./annotorious-selector-pack.js" type="text/javascript"></script>
+		<script src="./annotorious-better-polygon.js" type="text/javascript"></script>
+		<script src="./simple_imageviewer.min.js" type="text/javascript"></script>
 	</body>
 </html>

--- a/source/Pict-Section-OpenSeaDragon.js
+++ b/source/Pict-Section-OpenSeaDragon.js
@@ -430,10 +430,10 @@ class PictSectionOpenSeaDragon extends libPictViewClass
 	 */
 	focusOnAnnotation(annotationID)
 	{
-		console.debug(`[focusOnAnnotation] id[${annotationID}]`);
+		this.log.debug(`[focusOnAnnotation] id[${annotationID}]`);
 		if (!annotationID)
 		{
-			console.warn('[focusOnAnnotation] no id provided, cannot focus on the associated element');
+			this.log.warn('[focusOnAnnotation] no id provided, cannot focus on the associated element');
 			return;
 		}
 		this.annotator.fitBoundsWithConstraints(annotationID);
@@ -583,7 +583,7 @@ class PictSectionOpenSeaDragon extends libPictViewClass
 		const annotationElement = this.pict.ContentAssignment.getElement(`[data-id="${ id }"]`);
 		if (!commentElement?.[0] || !annotationElement?.[0])
 		{
-			console.warn('An expected element was missing, cannot render annotation connection with id: ', id);
+			this.log.warn('An expected element was missing, cannot render annotation connection with id: ', id);
 			return;
 		}
 		const osdElementPosition = this?.viewer?.element?.getBoundingClientRect();


### PR DESCRIPTION
* example_applications: update the README
* [Pict-Section-OpenSeaDragon: refocus viewport when selecting annotation](https://github.com/stevenvelozo/pict-section-openseadragon/commit/7dbcc2a57b8dd035f0edbc1063e9dfa51f7a61e1)
   * This works well for focusing on a user selection!
   * This isn’t going to work for the annotation creation flow. The annotation creation hook only fires AFTER the annotation and comment are SAVED. We do get a createSelection event when the user first draws on the image, but at this point we don’t have an annotation ID - so can’t tell Annotorious to  re-focus the viewport for us.
* [refocus viewport on canvas double click](https://github.com/stevenvelozo/pict-section-openseadragon/pull/2/commits/e3bf5f3b59f50513c53ba5d469e0e9aecdae9a60)
  * alternative to dragging the canvas when we're zoomed in all the way
  * we only do this when we're all the way zoomed in to avoid clashing
   with the single click panning behavior